### PR TITLE
fix panic in skill updater

### DIFF
--- a/backend/src/core/skill_updater.rs
+++ b/backend/src/core/skill_updater.rs
@@ -49,6 +49,10 @@ impl SkillUpdater {
             .fetch_all(self.get_db())
             .await?;
 
+        if to_update.is_empty() {
+            return Ok(())
+        }
+
         let runtime_per_char =
             (self.config.skill_updater.runtime as f64) / (to_update.len() as f64);
         let sleep_duration = tokio::time::Duration::from_secs_f64(runtime_per_char);


### PR DESCRIPTION
When calculating the sleep duration, the configured interval was divided by the amount of characters. With an empty database, this resulted in infinity, which causes a panic when trying to convert it to a duration.