### PR TITLE
update admin role in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,7 @@ The Waitlist has three services (see below). Before starting the front end, both
    INSERT INTO admin (character_id, role, granted_at, granted_by_id)
    SELECT
        id AS character_id,
-       'council' AS role,
+       'Leadership' AS role,
        CURRENT_TIMESTAMP() AS granted_at,
        id AS granted_by_id
    FROM `character` WHERE name = 'YOUR CHARACTER NAME';


### PR DESCRIPTION
Since the role overhaul in 78b3fc2, the role mentioned in the setup instructions no longer exists, leading to characters with that role being logged out with an error about an invalid token.