### PR TITLE
Stop tracking non-relevant skills

### DIFF
--- a/backend/data/skills.yaml
+++ b/backend/data/skills.yaml
@@ -741,3 +741,11 @@ requirements:
       elite: 4
     Long Distance Jamming:
       elite: 4
+
+other:
+  # These skills are tracked by the skill_updater in addition
+  # to the skills set in the requirements array OR required by fits
+  - Amarr Drone Specialization
+  - Caldari Drone Specialization
+  - Minmatar Drone Specialization
+  - Mutated Drone Specialization

--- a/backend/eve-data-core/src/fitting.rs
+++ b/backend/eve-data-core/src/fitting.rs
@@ -120,6 +120,8 @@ impl Fitting {
     pub fn from_eft(eft: &str) -> Result<Vec<Fitting>, FitError> {
         let mut fittings = Vec::new();
         let mut section = 0;
+        let section_count = eft.trim().lines().filter(|&l| l == "").count();
+
         for line in eft.lines() {
             let line = line.trim();
 
@@ -154,7 +156,7 @@ impl Fitting {
                         Some(s) => (s.parse()?, true),
                     };
 
-                    let is_cargo = if section >= 7 {
+                    let is_cargo = if section >= section_count {
                         // Sections are high,med,low,rig,subsystem,drone, then cargo
                         true
                     } else {

--- a/backend/src/data/skills.rs
+++ b/backend/src/data/skills.rs
@@ -68,16 +68,17 @@ pub async fn load_skills(
 
     let mut result = HashMap::new();
     for skill in skills.skills {
-        // Security fix: Do not track non-relevant skills.
-        // SEE: https://github.com/the-outuni-project/legacy-waitlist/issues/41
-        if !tracked_skills.contains(&skill.skill_id) {
-            continue;
-        }
-
         result.insert(
             skill.skill_id as TypeID,
             skill.active_skill_level as SkillLevel,
         );
+
+        // Security fix: Do not track non-relevant skills. SEE: https://github.com/the-outuni-project/legacy-waitlist/issues/41
+        // We still want to return all skills in the results variable as this is useful for the fit checker system.
+        // However by using continue below this will stop skills being saved to the database, and from being used on skills pages.
+        if !tracked_skills.contains(&skill.skill_id) {
+            continue;
+        }
 
         let on_record = last_known_skills.get(&skill.skill_id);
         if let Some(on_record) = on_record {

--- a/backend/src/data/skills.rs
+++ b/backend/src/data/skills.rs
@@ -73,6 +73,7 @@ pub async fn load_skills(
         if !tracked_skills.contains(&skill.skill_id) {
             continue;
         }
+
         result.insert(
             skill.skill_id as TypeID,
             skill.active_skill_level as SkillLevel,

--- a/backend/src/tdf/skills.rs
+++ b/backend/src/tdf/skills.rs
@@ -80,6 +80,7 @@ fn build_skill_data() -> Result<SkillData, TypeError> {
     struct SkillFile {
         categories: HashMap<String, Vec<String>>,
         requirements: HashMap<String, HashMap<String, HashMap<String, SkillLevel>>>,
+        other: HashSet<String>,
     }
 
     let skill_data: SkillFile = yamlhelper::from_file("./data/skills.yaml");
@@ -121,6 +122,15 @@ fn build_skill_data() -> Result<SkillData, TypeError> {
     }
 
     extend_known_skills(&mut known_skills)?;
+
+    // Add "OTHER" skills to the 'relevant_skills' list,
+    // which is used to force the skill_updater to track skills not on fits
+    for skill_name in skill_data.other {
+        let skill_id = TypeDB::id_of(&skill_name)?;
+        if !known_skills.contains(&skill_id) {
+            known_skills.insert(skill_id);
+        }
+    }
 
     let mut name_lookup = HashMap::new();
     let mut id_lookup = HashMap::new();

--- a/frontend/src/Pages/FC/announcements/Modals.js
+++ b/frontend/src/Pages/FC/announcements/Modals.js
@@ -20,12 +20,12 @@ const Small = styled.div`
 
 const TEMPLATES = {
   "Gankers in Focus": {
-    content: "GANKERS ARE IN FOCUS! Stay docked and read the fleet MOTD for instructions.",
+    content: "GANKERS ACTIVE: Please stay docked and read the fleet MOTD for instructions.",
     alert: true,
   },
   "Vanguard Fleet": {
     content:
-      "Fleet is running VGs. Remove your MWD/MJD and fit Tracking Computers or Sensor Boosters, and remove a Membrane and add a Signal Amplifier.",
+      "Refit for Vanguards: Remove your prop mods and a membrane and fit tracking computers, sensor boosters, and a signal amplifier.",
     alert: false,
   },
 };
@@ -43,6 +43,7 @@ const PageFilters = ({ idPrefix = "", selectedFilters, onChange }) => {
     if (selectedFilters !== values) {
       setValues(selectedFilters ?? []);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleClick = (e) => {
@@ -193,7 +194,7 @@ const AddAnnouncement = ({ isOpen, setOpen, refreshFunction }) => {
             <Button variant="danger" type="submit" disabled={pending}>
               Confirm
             </Button>
-            <Button variant="secondary" onClick={() => setOpen(false)}>
+            <Button variant="secondary" type='button' onClick={() => setOpen(false)}>
               Cancel
             </Button>
           </Buttons>


### PR DESCRIPTION
This is the first and hopefully only PR needed to address issue #41.

This PR:
- Adds a new section to `skills.yaml` called `other`. 

   The skill tracker only tracks skills listed in the requirement section of this file or skills required for modules on our fits.

   The `other` section allows us to specify additional skills we want to track. This is useful for tracking items that aren't listed on our fits but that would still be accepted (e.g., amarr/cal/min racial drone spec)


- Do not add skills to either database table if they are not a 'relevant skill'

- Do not fail fits because of missing skills for items in cargo